### PR TITLE
For custom group creation, flip the default display settings

### DIFF
--- a/CRM/Custom/Form/Group.php
+++ b/CRM/Custom/Form/Group.php
@@ -343,7 +343,7 @@ class CRM_Custom_Form_Group extends CRM_Core_Form {
       $defaults['weight'] = CRM_Utils_Weight::getDefaultWeight('CRM_Core_DAO_CustomGroup');
 
       $defaults['is_multiple'] = $defaults['min_multiple'] = 0;
-      $defaults['is_active'] = $defaults['is_public'] = $defaults['collapse_display'] = 1;
+      $defaults['is_active'] = $defaults['is_public'] = $defaults['collapse_adv_display'] = 1;
       $defaults['style'] = 'Inline';
     }
     elseif (empty($defaults['max_multiple']) && !$this->_isGroupEmpty) {


### PR DESCRIPTION
Overview
----------------------------------------
In the Custom Group creation screen, the default settings for collapsed display have caused discussion on whether the current defaults make sense. 

Discussion on Gitlab [here](https://lab.civicrm.org/dev/core/-/issues/2977).

Before
----------------------------------------
'Collapse this set on initial display' selected.
'Collapse this set in Advanced Search' unselected.

![image](https://user-images.githubusercontent.com/14126761/145906258-98164e65-6df4-40fc-a8f9-1e54b06a4c9d.png)

After
----------------------------------------
'Collapse this set on initial display' unselected.
'Collapse this set in Advanced Search' selected.

![image](https://user-images.githubusercontent.com/14126761/145906287-9bc09094-9b57-42fc-a777-81bff6e1d1f6.png)

Technical Details
----------------------------------------
N/A - fairly trivial change.

Comments
----------------------------------------

This is my first contribution to Core, I thought a simple change like this was a nice way to dip my toe into the water. I'm hoping to start contributing a bit more in future.

This was flagged in the 'community' CiviCRM Mattermost channel as needing community input [here](https://chat.civicrm.org/civicrm/pl/rofdzhzdhp8z7rzby1fs1ojsaa). 

The Gitlab discussion so far has a higher number of agreements to the proposal than disagreements, but it could possibly be a good idea to await further discussion.